### PR TITLE
Run rustfmt.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+indent_style="Block"
+imports_indent="Block"
+use_try_shorthand=true
+use_field_init_shorthand=true
+merge_imports=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: rust
 rust: stable
+before_script:
+- rustup component add rustfmt-preview
+script:
+- cargo fmt --all -- --check
+- cargo build
+- cargo test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub struct PackedVec<T> {
 #[derive(Debug)]
 pub struct PackedVecIter<'a, T>
 where
-    T: 'a + Unsigned + ToPrimitive + Ord + FromPrimitive,
+    T: 'a + FromPrimitive + Ord + ToPrimitive + Unsigned,
 {
     packed_vec: &'a PackedVec<T>,
     idx: usize,
@@ -38,7 +38,7 @@ where
 
 impl<'a, T> Iterator for PackedVecIter<'a, T>
 where
-    T: 'a + Unsigned + ToPrimitive + FromPrimitive + Ord,
+    T: 'a + FromPrimitive + Ord + ToPrimitive + Unsigned,
 {
     type Item = T;
 
@@ -50,7 +50,7 @@ where
 
 impl<'a, T> PackedVec<T>
 where
-    T: Unsigned + ToPrimitive + FromPrimitive + Ord,
+    T: FromPrimitive + Ord + ToPrimitive + Unsigned,
 {
     /// Return the value at the specified `index`
     /// # Example


### PR DESCRIPTION
No functional change, but simply runs rustfmt on the codebase. The second commit ensures that future PRs can't pass the Travis check unless the code was formatted with rustfmt. This is a bit draconian, but it'll help keep the style consistent going forward.

I've also taken this opportunity to squeeze in a couple of other no-functional-change-but-makes-things-a-bit-easier-to-read commits.