### PR TITLE
Allow users to specify the size of backing storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Gabriela Alexandra Moldovan <gabi_250@live.com>"]
 
 [dependencies]
-num = "0.1.40"
+num-traits = "0.2"
 rand = "0.3"
 serde = { version="1.0", features=["derive"], optional=true }

--- a/benches/packedvec.rs
+++ b/benches/packedvec.rs
@@ -1,0 +1,27 @@
+#![feature(test)]
+
+extern crate packed_vec;
+extern crate rand;
+extern crate test;
+
+use packed_vec::*;
+use test::Bencher;
+
+#[bench]
+fn creation(bench: &mut Bencher) {
+    let mut v = vec![];
+    for i in 0..10000u16 {
+        v.push(i);
+    }
+    bench.iter(|| PackedVec::new(v.clone()));
+}
+
+#[bench]
+fn iteration(bench: &mut Bencher) {
+    let mut v = vec![];
+    for i in 0..10000u16 {
+        v.push(i);
+    }
+    let pv = PackedVec::new(v);
+    bench.iter(|| pv.iter().collect::<Vec<_>>());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,78 +1,91 @@
-extern crate num;
+extern crate num_traits;
 extern crate rand;
 
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
 
-use num::{cast::FromPrimitive, ToPrimitive, Unsigned};
-use std::{cmp::Ord, marker::PhantomData};
-
-const WORD_SIZE: usize = 64;
+use num_traits::{cast::FromPrimitive, AsPrimitive, PrimInt, ToPrimitive, Unsigned};
+use std::{cmp::Ord, marker::PhantomData, mem::size_of};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PackedVec<T> {
+pub struct PackedVec<T, StorageT = usize> {
     len: usize,
-    bits: Vec<u64>,
+    bits: Vec<StorageT>,
     item_width: usize,
     phantom: PhantomData<T>,
 }
 
-impl<'a, T> PackedVec<T>
+impl<'a, T> PackedVec<T, usize>
 where
-    T: FromPrimitive + Ord + ToPrimitive + Unsigned,
+    T: 'static + AsPrimitive<usize> + FromPrimitive + Ord + PrimInt + ToPrimitive + Unsigned,
+    usize: AsPrimitive<T>,
 {
-    /// Return a `PackedVec` containing a compressed version of the elements of
-    /// `vec`.
-    pub fn new(vec: Vec<T>) -> PackedVec<T> {
-        let len = vec.len();
-        let item_width = if let Some(v) = vec.iter().max() {
-            i_log2((*v).to_u64().unwrap())
-        } else {
+    /// Constructs a new `PackedVec` from `vec`. The `PackedVec` has `usize` backing storage, which
+    /// is likely to be the best choice in nearly all situations.
+    pub fn new(vec: Vec<T>) -> Self {
+        PackedVec::new_with_storaget(vec)
+    }
+}
+
+impl<'a, T, StorageT> PackedVec<T, StorageT>
+where
+    T: 'static + AsPrimitive<StorageT> + FromPrimitive + Ord + PrimInt + ToPrimitive + Unsigned,
+    StorageT: AsPrimitive<T> + PrimInt + Unsigned,
+{
+    /// Constructs a new `PackedVec` from `vec` (with a user-defined backing storage type).
+    pub fn new_with_storaget(vec: Vec<T>) -> PackedVec<T, StorageT> {
+        if size_of::<T>() > size_of::<StorageT>() {
+            panic!("The backing storage type must be the same size or bigger as the stored integer size.");
+        }
+        if vec.len() == 0 {
             return PackedVec {
                 len: 0,
                 bits: vec![],
                 item_width: 0,
                 phantom: PhantomData,
             };
-        };
+        }
+
+        let item_width = i_log2(*vec.iter().max().unwrap());
         let mut bit_vec = vec![];
-        let mut buf: u64 = 0;
+        let mut buf = StorageT::zero();
         let mut bit_count: usize = 0;
-        for ref item in vec.iter() {
-            let item = item.to_u64().unwrap();
-            if bit_count + item_width < WORD_SIZE {
-                let shifted_item = item << WORD_SIZE - (item_width + bit_count);
-                buf |= shifted_item;
+        for item in &vec {
+            let item: StorageT = (*item).as_();
+            if bit_count + item_width < num_bits::<StorageT>() {
+                let shifted_item = item << num_bits::<StorageT>() - (item_width + bit_count);
+                buf = buf | shifted_item;
                 bit_count += item_width;
             } else {
-                let remaining_bits = WORD_SIZE - bit_count;
+                let remaining_bits = num_bits::<StorageT>() - bit_count;
                 // add as many bits as possible before adding the remaining
                 // bits to the next u64
                 let first_half = item >> (item_width - remaining_bits);
                 // for example if width = 5 and remaining_bits = 3
                 // item = 00101 -> add 001 to the buffer, insert buffer into
                 // bit array and create a new buffer containing 01 00000000...
-                buf |= first_half;
+                buf = buf | first_half;
                 bit_vec.push(buf);
-                buf = 0;
+                buf = StorageT::zero();
                 bit_count = 0;
                 if item_width - remaining_bits > 0 {
-                    let mask = (1 << (item_width - remaining_bits)) - 1;
+                    let mask = (StorageT::one() << (item_width - remaining_bits)) - StorageT::one();
                     let mut second_half = item & mask;
                     bit_count += item_width - remaining_bits;
                     // add the second half of the number to the buffer
-                    second_half <<= WORD_SIZE - bit_count;
-                    buf |= second_half;
+                    second_half = second_half << num_bits::<StorageT>() - bit_count;
+                    buf = buf | second_half;
                 }
             }
         }
-        if buf != 0 {
+        if buf != StorageT::zero() {
             bit_vec.push(buf);
         }
+
         PackedVec {
-            len,
+            len: vec.len(),
             bits: bit_vec,
             item_width,
             phantom: PhantomData,
@@ -92,29 +105,32 @@ where
         if index >= self.len {
             return None;
         }
-        let item_index = (index * self.item_width) / WORD_SIZE;
-        let start = (index * self.item_width) % WORD_SIZE;
-        if start + self.item_width < WORD_SIZE {
-            let mask = ((1 << self.item_width) - 1) << (WORD_SIZE - self.item_width - start);
-            let item = (self.bits[item_index].to_u64().unwrap() & mask)
-                >> (WORD_SIZE - self.item_width - start);
-            Some(FromPrimitive::from_u64(item).unwrap())
-        } else if self.item_width == WORD_SIZE {
-            Some(FromPrimitive::from_u64(self.bits[item_index].to_u64().unwrap()).unwrap())
+        let item_index = (index * self.item_width) / num_bits::<StorageT>();
+        let start = (index * self.item_width) % num_bits::<StorageT>();
+        if start + self.item_width < num_bits::<StorageT>() {
+            let mask = ((StorageT::one() << self.item_width) - StorageT::one())
+                << (num_bits::<StorageT>() - self.item_width - start);
+            let item = (self.bits[item_index] & mask)
+                >> (num_bits::<StorageT>() - self.item_width - start);
+            Some(item.as_())
+        } else if self.item_width == num_bits::<StorageT>() {
+            Some(self.bits[item_index].as_())
         } else {
-            let bits_written = WORD_SIZE - start;
-            let mask = ((1 << bits_written) - 1) << (WORD_SIZE - bits_written - start);
-            let first_half = (self.bits[item_index].to_u64().unwrap() & mask)
-                >> (WORD_SIZE - bits_written - start);
+            let bits_written = num_bits::<StorageT>() - start;
+            let mask = ((StorageT::one() << bits_written) - StorageT::one())
+                << (num_bits::<StorageT>() - bits_written - start);
+            let first_half =
+                (self.bits[item_index] & mask) >> (num_bits::<StorageT>() - bits_written - start);
             // second half
             let remaining_bits = self.item_width - bits_written;
             if remaining_bits > 0 {
-                let mask = ((1 << remaining_bits) - 1) << (WORD_SIZE - remaining_bits);
-                let second_half = (self.bits[item_index + 1].to_u64().unwrap() & mask)
-                    >> (WORD_SIZE - remaining_bits);
-                Some(FromPrimitive::from_u64((first_half << remaining_bits) + second_half).unwrap())
+                let mask = ((StorageT::one() << remaining_bits) - StorageT::one())
+                    << (num_bits::<StorageT>() - remaining_bits);
+                let second_half =
+                    (self.bits[item_index + 1] & mask) >> (num_bits::<StorageT>() - remaining_bits);
+                Some(((first_half << remaining_bits) + second_half).as_())
             } else {
-                Some(FromPrimitive::from_u64(first_half).unwrap())
+                Some(first_half.as_())
             }
         }
     }
@@ -132,26 +148,24 @@ where
     }
 
     /// An iterator over the elements of the vector.
-    pub fn iter(&'a self) -> PackedVecIter<'a, T> {
+    pub fn iter(&'a self) -> PackedVecIter<'a, T, StorageT> {
         PackedVecIter {
-            packed_vec: &self,
+            packed_vec: self,
             idx: 0,
         }
     }
 }
 
 #[derive(Debug)]
-pub struct PackedVecIter<'a, T>
-where
-    T: 'a + FromPrimitive + Ord + ToPrimitive + Unsigned,
-{
-    packed_vec: &'a PackedVec<T>,
+pub struct PackedVecIter<'a, T: 'a, StorageT: 'a> {
+    packed_vec: &'a PackedVec<T, StorageT>,
     idx: usize,
 }
 
-impl<'a, T> Iterator for PackedVecIter<'a, T>
+impl<'a, T, StorageT> Iterator for PackedVecIter<'a, T, StorageT>
 where
-    T: 'a + FromPrimitive + Ord + ToPrimitive + Unsigned,
+    T: 'static + AsPrimitive<StorageT> + FromPrimitive + Ord + PrimInt + ToPrimitive + Unsigned,
+    StorageT: AsPrimitive<T> + PrimInt + Unsigned,
 {
     type Item = T;
 
@@ -161,9 +175,14 @@ where
     }
 }
 
-fn i_log2(number: u64) -> usize {
-    let mut bits = 63;
-    while number & (1 << bits) == 0 {
+/// How many bits does this type represent?
+fn num_bits<T>() -> usize {
+    size_of::<T>() * 8
+}
+
+fn i_log2<T: PrimInt>(number: T) -> usize {
+    let mut bits = num_bits::<T>() - 1;
+    while number & (T::one() << bits) == T::zero() {
         bits -= 1;
     }
     bits + 1
@@ -172,7 +191,7 @@ fn i_log2(number: u64) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand;
+    use rand::Rand;
 
     #[test]
     fn empty_vec() {
@@ -226,7 +245,7 @@ mod tests {
 
     #[test]
     fn values_fill_item_width() {
-        let v: Vec<u64> = vec![1, 2, 9223372036854775808, 100, 0, 3];
+        let v: Vec<usize> = vec![1, 2, 9223372036854775808, 100, 0, 3];
         let v_len = v.len();
         let packed_v = PackedVec::new(v.clone());
         assert_eq!(packed_v.len(), v_len);
@@ -302,25 +321,45 @@ mod tests {
         assert_eq!(iter.next(), None);
     }
 
-    fn random_unsigned_ints<T>()
+    fn random_unsigned_ints<T, StorageT>()
     where
-        T: Unsigned + ToPrimitive + FromPrimitive + Ord + Clone + std::fmt::Debug + rand::Rand,
+        T: 'static
+            + AsPrimitive<StorageT>
+            + FromPrimitive
+            + Ord
+            + PrimInt
+            + Rand
+            + ToPrimitive
+            + Unsigned,
+        StorageT: AsPrimitive<T> + PrimInt + Unsigned,
     {
         const LENGTH: usize = 100000;
         let mut v: Vec<T> = Vec::with_capacity(LENGTH);
         for _ in 0..(LENGTH + 1) {
             v.push(rand::random::<T>());
         }
-        let packed_v = PackedVec::new(v.clone());
+        let packed_v = PackedVec::<T, StorageT>::new_with_storaget(v.clone());
         assert_eq!(packed_v.len(), v.len());
         assert!(packed_v.iter().zip(v.iter()).all(|(x, y)| x == *y));
     }
 
     #[test]
     fn random_vec() {
-        random_unsigned_ints::<u8>();
-        random_unsigned_ints::<u16>();
-        random_unsigned_ints::<u32>();
-        random_unsigned_ints::<u64>();
+        random_unsigned_ints::<u8, u8>();
+        random_unsigned_ints::<u8, u16>();
+        random_unsigned_ints::<u8, u32>();
+        random_unsigned_ints::<u8, u64>();
+        random_unsigned_ints::<u16, u16>();
+        random_unsigned_ints::<u16, u32>();
+        random_unsigned_ints::<u16, u64>();
+        random_unsigned_ints::<u32, u32>();
+        random_unsigned_ints::<u32, u64>();
+        random_unsigned_ints::<u64, u64>();
+    }
+
+    #[test]
+    #[should_panic]
+    fn t_must_not_be_bigger_than_storaget() {
+        PackedVec::<u16, u8>::new_with_storaget(vec![0]);
     }
 }


### PR DESCRIPTION
Previously the backing storage was fixed to `u64`, which probably isn't optimal for non-64 bit machines. The default is now to use `usize` storage as the backing, which is probably the best option in nearly all cases: but, in case someone knows something more (e.g. a machine where usize is 64-bit, but 128-bit integer operations are as fast as 64-bit operations), we allow them to override this. In general, however, this has no effect on the API.

I also squeezed in a bug fix (https://github.com/softdevteam/packed-vec/commit/840fb493d650a2e3a48cc28400711d4b571cea8a), on my way to creating some (very, very, very) simple benchmarks (https://github.com/softdevteam/packed-vec/commit/7b4c4b4bd52c8d5ac5254c293ae7698214e9b0ca). The benchmarks confirm that this PR makes no meaningful difference to performance.

[Interestingly, though, I found cases where the I *can* get big performance improvements. If, for example, your data is 16-bits wide, then using `u16` storage is much, much faster than `usize`. But if you knew that, you'd use a `Vec<u16>`!]