### PR TITLE
Ensure the last bits of a `PackedVec` are stored, even if they are 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ where
                 }
             }
         }
-        if buf != StorageT::zero() {
+        if bit_count != 0 {
             bit_vec.push(buf);
         }
 
@@ -380,5 +380,19 @@ mod tests {
         assert_eq!(pv.get(1), Some(0));
         assert_eq!(pv.get(2), None);
         assert_eq!(pv.iter().collect::<Vec<u16>>(), vec![0, 0]);
+    }
+
+    #[test]
+    fn zero_bits_spanning_across_elements() {
+        let v: Vec<u64> = vec![0, 5, 17, 17, 6, 3, 25, 29, 10, 0, 10, 0, 2];
+        let v_len = v.len();
+        let pv = PackedVec::new(v.clone());
+        assert_eq!(pv.len(), v_len);
+        let mut iter = pv.iter();
+        for number in v {
+            let value: Option<u64> = iter.next();
+            assert_eq!(value, Some(number));
+        }
+        assert_eq!(iter.next(), None);
     }
 }


### PR DESCRIPTION
A `PackedVec` consists of multiple `StorageT` units which contain the bits of the elements in the original vector. The elements of the original vector are added one by one to a buffer (`buf`) of type `StorageT`, until the buffer becomes full. When the buffer is full, it is stored in the `PackedVec`, and its value is set back to 0. The remaining bits of the original vector are processed in a similar way, using `buf`. 

Once all the elements of the input `vec` have been processed, it may be necessary to 'flush' the remaining bits from the buffer. This is because the buffer is only stored in the `PackedVec` as a `StorageT` value when it is full. However, the last elements of the input vector may not actually fill the entire buffer, so we have to check if the buffer is non-empty at the end of the computation.  The correct check is `bit_count != 0` (`bit_count` is the number of bits currently in `buf`), and not `buf != 0`, because `buf` may be equal to 0 and actually contain the least significant bits of the last element in the vector (which could all be 0). 

Fixes #6