### PR TITLE
Triple license Apache-2.0/MIT/UPL-1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "packed_vec"
 version = "0.1.0"
 authors = ["Gabriela Alexandra Moldovan <gabi_250@live.com>"]
+readme = "README.md"
+# This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
+# UPL-1.0.
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 num-traits = "0.2"

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,4 @@
-MIT License
-
-Copyright (c) 2017 Gabriela Alexandra Moldovan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Except as otherwise noted, this project is licensed under the Apache License,
+Version 2.0 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>, or
+the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>, or the
+UPL-1.0 license <http://opensource.org/licenses/UPL> at your option.

--- a/benches/packedvec.rs
+++ b/benches/packedvec.rs
@@ -1,3 +1,12 @@
+// Copyright (c) 2018 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
 #![feature(test)]
 
 extern crate packed_vec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2017 Garbiela Alexandra Moldovan
+// Copyright (c) 2018 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
 extern crate num_traits;
 extern crate rand;
 


### PR DESCRIPTION
As discussed with Gabi, this moves us more in line with most other Rust libraries (and, as a bonus, adds the UPL-1.0).