### PR TITLE
Allow signed types / negative values to be packed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,12 +199,7 @@ fn num_bits<T>() -> usize {
 }
 
 fn i_log2<T: PrimInt + Unsigned>(n: T) -> usize {
-    debug_assert!(n > T::zero());
-    let mut bits = num_bits::<T>() - 1;
-    while n & (T::one() << bits) == T::zero() {
-        bits -= 1;
-    }
-    bits + 1
+    size_of::<T>() * 8 - n.leading_zeros() as usize
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The main aim of this PR is to allow signed types to be used with PackedVec: that means that we have to deal with negative numbers. This causes a great deal of complication in the `delta()` and `inv_delta()` functions because signed types are not symmetric: `i8::min_value()` == -128 but `i8::max_value()` == 127. We therefore have to do a very delicate dance. I'm not sure I've got it right; and, if I've got it right, I'm not sure I've done it efficiently. But, at least, I can't find obvious test cases which kill it now.

Making this commit practical has an interesting knock-on effect: it's now clear that we can't use 0 as our base. Imagine if someone has a vec `[9998,9999,10000]` -- previously we needed 14 bits to store that. But really the effective range is 2, which we only need 2 bits to store. This becomes vital with signed types, where we probably wouldn't want to use T::min_value() as our base. So the vec above really is stored with items 1 bit wide.

This does slow things down a bit, both in terms of creation and retrieving elements, but the slow-down is about 5%, which for the extra generality is probably worth it. We could, in the future, probably get that performance back and maintain the same API if we really cared about it.